### PR TITLE
Fix: table line and date picker text color

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -162,7 +162,7 @@ const disableMonthBtn = ({
 
   return {
     disabled,
-    className: disabled ? 'text-gray-300 border-white' : 'text-gray-800'
+    className: composeClasses(disabled && 'text-gray-300 border-white')
   }
 }
 
@@ -181,7 +181,7 @@ const disabledYearBtn = ({
 
   return {
     disabled,
-    className: disabled ? 'text-gray-300' : 'text-gray-800'
+    className: composeClasses(disabled && 'text-gray-300')
   }
 }
 

--- a/src/components/Table/table.css
+++ b/src/components/Table/table.css
@@ -40,6 +40,8 @@
   width: 1px;
   height: 100%;
   background-color: #8f969a;
+  transform: translateZ(0);
+  -webkit-transform: translateZ(0);
 }
 
 .table-container-cmpnt.vertical-borders thead tr th:last-child::after,


### PR DESCRIPTION
## Summary

- Force hardware acceleration on the table pseudoelement to fix visual bug on Chrome
- Change date picker text when month is selected to color white

## Task

- https://dd360.atlassian.net/browse/CD-1155

## Affected sections

- src/components/DatePicker/DatePicker.tsx
- src/components/Table/table.css

## How did you test this change?

- Manually
