### PR TITLE
fix(Input): bug the absolute position

### DIFF
--- a/src/components/Form/Input/BaseInput.tsx
+++ b/src/components/Form/Input/BaseInput.tsx
@@ -191,7 +191,7 @@ const BaseInput = forwardRef<HTMLDivElement, InputProps>(
             {...otherProps}
             placeholder={isLabelScalded ? placeholder : ''}
             className={composeClasses(
-              'outline-none w-full h-full font-medium bg-transparent absolute'
+              'outline-none w-full h-full font-medium bg-transparent absolute left-0 right-0'
             )}
             onFocus={handleFocus}
             onBlur={handleBlur}


### PR DESCRIPTION
## Summary

In some cases, it happens that the input is positioned after the "label", because it has not set the "position", it was only indicated that the "position" is of type "absolute".

The bug was fixed by adding a left-0 right-0 in the input.

## Task
 
[Jira task](https://dd360.atlassian.net/jira/software/c/projects/CD/boards/12?modal=detail&selectedIssue=CD-1708&assignee=63ea68ce9e626e54cc5ac59f)

## How did you test this change?

- Manually in storybook

- Tested in dd360:

![image](https://github.com/dd3tech/bui/assets/127885606/4af80e88-16d6-45e6-b06c-c3987e34838f)

