### PR TITLE
fix(TextArea): add missing className prop 

### DIFF
--- a/src/components/Form/TextArea.tsx
+++ b/src/components/Form/TextArea.tsx
@@ -67,7 +67,7 @@ function TextArea({
       classNameAdornment
     ),
     container: composeClasses(
-      'w-full placeholder-gray-400 mt-1 flex items-center justify-between font-medium relative',
+      'w-full placeholder-gray-400 mt-1 flex items-center justify-between font-medium relative h-auto',
       'border-solid border',
       'transition duration-500 ease-out focus:ease-in',
       !isDisabled && `hover:shadow-${boxShadow} hover:border-info`,

--- a/src/components/Form/TextArea.tsx
+++ b/src/components/Form/TextArea.tsx
@@ -28,6 +28,7 @@ export interface TextAreaProps
   large?: boolean
   boxShadow?: ShadowVariants
   isRequired?: boolean
+  classNameTextArea?: string
 }
 
 function TextArea({
@@ -46,6 +47,7 @@ function TextArea({
   onFocus,
   onBlur,
   isRequired,
+  classNameTextArea,
   ...otherProps
 }: TextAreaProps) {
   const { disabled } = otherProps
@@ -67,7 +69,7 @@ function TextArea({
       classNameAdornment
     ),
     container: composeClasses(
-      'w-full placeholder-gray-400 mt-1 flex items-center justify-between font-medium relative h-auto',
+      'w-full placeholder-gray-400 mt-1 flex items-center justify-between font-medium relative',
       'border-solid border',
       'transition duration-500 ease-out focus:ease-in',
       !isDisabled && `hover:shadow-${boxShadow} hover:border-info`,
@@ -121,8 +123,9 @@ function TextArea({
           ref={textAreaRef}
           {...otherProps}
           className={composeClasses(
-            'w-full h-full bg-transparent focus:outline-none',
-            isDisabled && 'cursor-not-allowed'
+            'w-full bg-transparent focus:outline-none',
+            isDisabled && 'cursor-not-allowed',
+            classNameTextArea
           )}
           placeholder={isLabelScalded ? placeholder : ''}
           disabled={isDisabled}


### PR DESCRIPTION
Add prop in text area

## Summary

A prop was added to be able to customize the size of the text area

## Task

[TextArea](https://dd360.atlassian.net/jira/software/c/projects/CD/boards/12?assignee=6397d027fbf54baf29036449&selectedIssue=CD-2098)

## Affected sections

- src/components/Form/TextArea.tsx

## How did you test this change?

* Mannualy with storybook 🎨
* Added test to tooltip component 🤖
* All tests was passed ✅~
