### PR TITLE
fix(text): Added validation of a negative number in currency type text

### DIFF
--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -103,6 +103,7 @@ const getComponent = (props: TextProps, ref: LegacyRef<any>): JSX.Element => {
     case 'currency':
       return (
         <p {...props} ref={ref}>
+          {props.children && Number(props.children) < 0 && '-'}
           {props.children && format(props.children)}
         </p>
       )


### PR DESCRIPTION
## Summary

Added validation of a negative number in currency type text

## Task

not

## Affected sections

- src/components/Typography/Text.tsx

## How did you test this change?

* Mannualy with storybook 🎨
* Added test to tooltip component 🤖
* All tests was passed ✅
