### PR TITLE
fix(useResize): Fix cases where window was undefined

### DIFF
--- a/src/hooks/useResize.ts
+++ b/src/hooks/useResize.ts
@@ -28,28 +28,28 @@ export default function useResize(): useResizeReturnedTypes {
     width: undefined,
     height: undefined
   })
+  const [isMobile, setIsMobile] = useState<boolean>(false)
+  const [isMdScreen, setIsMdScreen] = useState<boolean>(false)
 
   const handleChangeResize = useCallback(() => {
+    if (typeof window === undefined) return
     setSize({
       width: window.innerWidth,
       height: window.innerHeight
     })
+    setIsMobile(window.innerWidth < 768)
+    setIsMdScreen(window.innerWidth <= 1024)
   }, [])
 
   useEffect(() => {
-    if (!size.width || !size.height) {
-      setSize({
-        width: window.innerWidth,
-        height: window.innerHeight
-      })
-    }
+    handleChangeResize()
     window?.addEventListener('resize', handleChangeResize)
     return () => window.removeEventListener('resize', handleChangeResize)
   }, [])
 
   return {
     size,
-    isMobile: window.innerWidth < 768,
-    isMdScreen: window.innerWidth <= 1024
+    isMobile,
+    isMdScreen
   }
 }

--- a/src/hooks/useResize.ts
+++ b/src/hooks/useResize.ts
@@ -44,7 +44,7 @@ export default function useResize(): useResizeReturnedTypes {
   useEffect(() => {
     handleChangeResize()
     window?.addEventListener('resize', handleChangeResize)
-    return () => window.removeEventListener('resize', handleChangeResize)
+    return () => window?.removeEventListener('resize', handleChangeResize)
   }, [])
 
   return {


### PR DESCRIPTION
## Summary

When working with Next.js, there are some cases in which this hook fails, as the page is being loaded on the server and `window` is undefined.

## Affected sections

- useResize.ts

## How did you test this change?

- Manually
