### PR TITLE
feat(SideBar): Allow custom element in the dangerZone

### DIFF
--- a/src/components/SideBar/SideBar.test.tsx
+++ b/src/components/SideBar/SideBar.test.tsx
@@ -58,6 +58,7 @@ const props = {
   sideBarSubTitle: 'Subtitle text',
   sideBarList: sideBarList,
   disabledOptionsTag: 'Próximamente',
+  renderBottomCmp: () => <div>Custom element</div>,
   dangerZone: {
     show: true,
     text: 'Eliminar proyecto',
@@ -237,5 +238,9 @@ describe('<SideBar/>', () => {
     )
 
     expect(renderResult.getByRole('list-options').children).toHaveLength(4)
+  })
+
+  it('bottom element is displayed when included', () => {
+    expect(renderResult.getByRole('bottom-element')).toBeDefined()
   })
 })

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -58,6 +58,10 @@ export interface SideBarProps {
    * Indicates if the sidebar will be expanded by default
    */
   defaultExpand?: boolean
+  /**
+   * Custom element above the danger zone
+   */
+  renderBottomCmp?: (isExpanded: boolean) => ReactNode
   dangerZone?: {
     /**
      * Show danger zone
@@ -123,6 +127,7 @@ const SideBar = ({
   isLoadingSideBarList,
   numSkeletons = 5,
   style,
+  renderBottomCmp,
   dangerZone
 }: SideBarProps) => {
   const sidebarRef: MutableRefObject<HTMLDivElement | null> =
@@ -286,11 +291,23 @@ const SideBar = ({
               )
             )}
           </div>
+          {renderBottomCmp && (
+            <Flex
+              role="bottom-element"
+              alignItems="center"
+              className="w-full mb-4 mt-8 relative"
+            >
+              {renderBottomCmp(expand)}
+            </Flex>
+          )}
           {dangerZone?.show && (
             <Flex
               role="danger-zone"
               alignItems="center"
-              className="w-full cursor-pointer group mb-4 mt-8 relative"
+              className={composeClasses(
+                'w-full cursor-pointer group mb-4 relative',
+                !renderBottomCmp && 'mt-8'
+              )}
               onClick={() => {
                 if (dangerZone?.callBack) {
                   flushSync


### PR DESCRIPTION
## Summary

Add a new prop `renderBottomCmp`, to allow placing custom elements at the bottom of the SideBar.

#### Usage
```
<SideBar
  sideBarName="Sidebar"
  renderBottomCmp={(isExpand) => <MyComponent isExpand={isExpand}/>}
/>
```

## Task

This is a required change in order to complete the following task (see Figma): 
- [AK-61](https://dd360.atlassian.net/browse/AK-61)

## Affected sections

- SideBar.tsx

## How did you test this change?

### This is what it would look like

### Only using renderBottomCmp

![screenshot-1701129340](https://github.com/dd3tech/bui/assets/42563977/d0ce60e2-c052-4dab-b34d-af722517a7df)
![screenshot-1701129398](https://github.com/dd3tech/bui/assets/42563977/25ee763a-93b1-4bfc-a804-e5c6c0542be2)

### Using dangerZone & renderBottomCmp

![screenshot-1701128441](https://github.com/dd3tech/bui/assets/42563977/fb3e0698-bbcf-473c-b07c-8525cc9995b5)
![screenshot-1701128491](https://github.com/dd3tech/bui/assets/42563977/235b6bca-5cca-4429-8e54-7734098d77c8)

### Only dangerZone

![screenshot-1701128544](https://github.com/dd3tech/bui/assets/42563977/61c6f4f1-0381-4f66-a54e-afa9403b608a)
![screenshot-1701128561](https://github.com/dd3tech/bui/assets/42563977/f486d22c-c7df-4dd6-aef4-37612db85f3f)
