### PR TITLE
Fix(Modal): The iconBtnClose prop was added

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) DD360 and its affiliates.
  */
 
-import { forwardRef } from 'react'
+import { ReactNode, forwardRef } from 'react'
 import { useModalManager } from 'hooks'
 import { composeClasses } from 'lib/classes'
 import './modal.css'
@@ -73,6 +73,12 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
    * This prop define if it has the close button.
    */
   btnClose?: boolean
+
+  /**
+   * Optional.
+   * This prop specifies the icon to be used for the close button.
+   */
+  iconBtnClose?: ReactNode
 }
 
 const Modal = forwardRef<HTMLDivElement, ModalProps>(
@@ -90,6 +96,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
       setCloseModal,
       width,
       btnClose = true,
+      iconBtnClose,
       ...props
     }: ModalProps,
     ref
@@ -143,22 +150,24 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
                   onClick={handleModalClose}
                   className="absolute top-0 right-0  mr-6 cursor-pointer mt-6"
                 >
-                  <svg
-                    className="cursor-pointer"
-                    width="18"
-                    height="18"
-                    viewBox="0 0 18 18"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M1 17L17 1M1 1L17 17"
-                      stroke="var(--primary)"
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
+                  {iconBtnClose ?? (
+                    <svg
+                      className="cursor-pointer"
+                      width="18"
+                      height="18"
+                      viewBox="0 0 18 18"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 17L17 1M1 1L17 17"
+                        stroke="var(--primary)"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  )}
                 </div>
               )}
               <div className="mt-4 mb-4 w-full">{children}</div>


### PR DESCRIPTION
## Summary

The iconBtnClose prop was added to be able to customize the close button

## Task

not

## Affected sections

- src/components/Modal/Modal.tsx

## How did you test this change?

* Mannualy with storybook 🎨
* Added test to tooltip component 🤖
* All tests was passed ✅~
