### PR TITLE
Fix(Tab-Tabgroup): Styles are added when hovering in the tabs

### DIFF
--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -82,9 +82,12 @@ const Tab = forwardRef<HTMLButtonElement, Props>(
         role="tab"
         disabled={disabled}
         onClick={handleClick}
-        style={{ color: textColor && index === value ? textColor : undefined }}
+        style={{
+          color: textColor && index === value ? textColor : undefined,
+          minWidth: '132px'
+        }}
         className={composeClasses(
-          'inline-flex justify-center flex-wrap items-center box-content leading-5 select-none transition-all duration-300 ease-in  hover:bg-gray-50 hover:border-blue-400',
+          'inline-flex justify-center w-auto flex-wrap items-center box-content leading-5 select-none transition-all duration-300 ease-in  hover:bg-gray-50 hover:border-blue-400',
           isVertical ? 'border-r-3' : 'border-b-3',
           classes,
           variantStyle[variant],

--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -23,6 +23,7 @@ interface Props
   label: string
   disabled?: boolean
   hidden?: boolean
+  isVertical?: boolean
 }
 
 const variantStyle = {
@@ -40,6 +41,7 @@ const Tab = forwardRef<HTMLButtonElement, Props>(
       textColor,
       className,
       hidden,
+      isVertical,
       ...otherProps
     },
     ref
@@ -82,7 +84,8 @@ const Tab = forwardRef<HTMLButtonElement, Props>(
         onClick={handleClick}
         style={{ color: textColor && index === value ? textColor : undefined }}
         className={composeClasses(
-          'inline-flex justify-center flex-wrap items-center box-content leading-5 select-none transition-all duration-300 ease-in',
+          'inline-flex justify-center flex-wrap items-center box-content leading-5 select-none transition-all duration-300 ease-in  hover:bg-gray-50 hover:border-blue-400',
+          isVertical ? 'border-r-3' : 'border-b-3',
           classes,
           variantStyle[variant],
           className,

--- a/src/components/Tabs/TabGroup.tsx
+++ b/src/components/Tabs/TabGroup.tsx
@@ -142,6 +142,7 @@ function TabGroup({
           variant,
           disabledText,
           className: childClassName,
+          isVertical: orientation === 'vertical',
           ...child.props
         })
       }
@@ -189,10 +190,12 @@ function TabGroup({
             ...dashRect,
             backgroundColor: !indicatorColor?.includes('bg-')
               ? indicatorColor
-              : undefined
+              : undefined,
+            bottom: '1px',
+            right: '1px'
           }}
           className={composeClasses(
-            'bg-blue-500 transition-all duration-300 ease-in absolute bottom-0',
+            'bg-blue-500 transition-all duration-300 ease-in absolute',
             indicatorColor?.includes('bg-') && indicatorColor
           )}
         />

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -80,7 +80,7 @@ describe('<TabGroup /> variant="primary ', () => {
     const indicationBar = result.getByRole('indication-bar')
 
     expect(indicationBar).toBeDefined()
-    expect(indicationBar.style.right).toBe('0px')
+    expect(indicationBar.style.right).toBe('1px')
     expect(indicationBar.style.width).toBe('3.5px')
     expect(indicationBar.className).toContain('bg-purple-500')
   })


### PR DESCRIPTION
## Summary

Styles are added when hovering in the tabs

## Task

not

## Affected sections

- src/components/Tabs/TabGroup.tsx
- src/components/Tabs/Tab.tsx
- src/components/Tabs/Tabs.test.tsx

## How did you test this change?

* Mannualy with storybook 🎨
* Added test to tooltip component 🤖
* All tests was passed ✅~
