### PR TITLE
Fix(TextArea): Validation was added to the padding depending on the label

### DIFF
--- a/src/components/Form/TextArea.tsx
+++ b/src/components/Form/TextArea.tsx
@@ -131,7 +131,7 @@ function TextArea({
           disabled={isDisabled}
           onFocus={handleFocus}
           onBlur={handleBlur}
-          style={{ zIndex: 1, paddingTop: 10 }}
+          style={{ zIndex: 1, paddingTop: label ? 10 : 0 }}
         />
         {endAdornment && (
           <div


### PR DESCRIPTION
add validation padding

## Summary

Validation was added to the padding depending on the label

## Task

not

## Affected sections

- src/components/Form/TextArea.tsx

## How did you test this change?

* Mannualy with storybook 🎨
* Added test to tooltip component 🤖
* All tests was passed ✅~
