### PR TITLE
Feat: add custom decimals to percentage input

### DIFF
--- a/src/components/Form/Input/BaseInput.tsx
+++ b/src/components/Form/Input/BaseInput.tsx
@@ -92,6 +92,10 @@ export interface InputProps
    * It can be either 'es' for Spanish or 'en' for English.
    */
   language?: 'es' | 'en'
+  /**
+   * The suffix to be displayed after the input value.
+   */
+  decimalsLimit?: number
 }
 
 const BaseInput = forwardRef<HTMLDivElement, InputProps>(

--- a/src/components/Form/Input/BaseInput.tsx
+++ b/src/components/Form/Input/BaseInput.tsx
@@ -93,7 +93,8 @@ export interface InputProps
    */
   language?: 'es' | 'en'
   /**
-   * The suffix to be displayed after the input value.
+   * The maximum number of decimal places allowed in the input value.
+   * Default = 2
    */
   decimalsLimit?: number
 }

--- a/src/components/Form/Input/CurrencyInput.tsx
+++ b/src/components/Form/Input/CurrencyInput.tsx
@@ -30,10 +30,6 @@ export interface InputCurrencyProps extends InputProps {
    * The maximum number of decimal places allowed in the input value.
    * Default = 2
    */
-  decimalsLimit?: number
-  /**
-   * The suffix to be displayed after the input value.
-   */
   suffix?: string
   /**
    * The number of decimal places that will appear after the decimalSeparator prop.

--- a/src/components/Form/Input/PercentageInput.test.tsx
+++ b/src/components/Form/Input/PercentageInput.test.tsx
@@ -54,4 +54,14 @@ describe('<PercentageInput />', () => {
     fireEvent.change(input, { target: { value: '100' } })
     expect(input.value).toBe('100')
   })
+
+  it('should render the value using custom decimals', () => {
+    const { getByRole } = render(
+      <PercentageInput decimalsLimit={6} {...defaultProps} />
+    )
+    const input = getByRole('percentage-input') as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: '12.123456' } })
+    expect(input.value).toBe('12.123456')
+  })
 })

--- a/src/components/Form/Input/PercentageInput.tsx
+++ b/src/components/Form/Input/PercentageInput.tsx
@@ -6,15 +6,24 @@ import { useCallback, useState, useEffect } from 'react'
 import BaseInput, { InputProps } from './BaseInput'
 
 function PercentageInput(props: InputProps) {
-  const { onChange, value } = props
+  const { onChange, value, decimalsLimit = 2 } = props
   const [localValue, setLocalValue] = useState(value || 0)
+
+  function getRegexDecimal(numDecimals: number) {
+    numDecimals = Math.max(0, numDecimals)
+
+    const regexPattern = new RegExp(
+      `^(100(?![.])?|\\d{1,2}(\\.\\d{1,${numDecimals}})?|\\d{1,2}(\\.\\d{0,${numDecimals}})?|)$`
+    )
+
+    return regexPattern
+  }
 
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      const validatePercentage =
-        /^(100(?!\.)?|\d{1,2}(\.\d{1,2})?|\d{1,2}(\.\d{0,2})?|)$/.test(
-          event.target.value
-        )
+      const validatePercentage = getRegexDecimal(decimalsLimit).test(
+        event.target.value
+      )
       if (validatePercentage) {
         setLocalValue(event.target.value)
         onChange && onChange(event)


### PR DESCRIPTION
## Summary

Add prop to customize the number of decimals on the percentage input

## Task


## Affected sections

- src/components/Form/Input/BaseInput.tsx
- src/components/Form/Input/CurrencyInput.tsx
- src/components/Form/Input/PercentageInput.test.tsx
- src/components/Form/Input/PercentageInput.tsx

## How did you test this change?

- Manually
- src/components/Form/Input/PercentageInput.test.tsx