### PR TITLE
fix(Modal): added validation to prevent close modal

### DIFF
--- a/.storybook/themes.js
+++ b/.storybook/themes.js
@@ -24,6 +24,6 @@ export const customDD360 = create({
 
     brandTitle: 'DD360 Storybook',
     brandUrl: 'https://dd360.mx',
-    brandImage: 'https://dd360.mx/images/logo/DD360_LOGO.png',
+    brandImage: 'http://dd360-universe-static-assets-prod.s3.amazonaws.com/website/images/logo/DD360_LOGO.png',
     brandTarget: '_self'
 })

--- a/src/components/AsideModal/AsideModal.tsx
+++ b/src/components/AsideModal/AsideModal.tsx
@@ -103,7 +103,7 @@ const AsideModal: FC<IAsideModalProps> = ({
         <div
           role="btn-close"
           className="text-info cursor-pointer hover:text-primary transition ease-in-out duration-300"
-          onClick={handleModalClose}
+          onClick={() => handleModalClose(true)}
         >
           <XCircleIcon className="w-6" />
         </div>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -131,7 +131,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
           style={{
             backgroundColor: overlay && !blur ? 'rgba(17, 24, 39, 0.75)' : ''
           }}
-          onClick={handleModalClose}
+          onClick={() => handleModalClose()}
           {...props}
         >
           <div className="flex items-center justify-center h-full">
@@ -147,7 +147,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
               {btnClose && (
                 <div
                   role="btn-close"
-                  onClick={handleModalClose}
+                  onClick={() => handleModalClose(true)}
                   className="absolute top-0 right-0  mr-6 cursor-pointer mt-6"
                 >
                   {iconBtnClose ?? (

--- a/src/hooks/useModalManager.ts
+++ b/src/hooks/useModalManager.ts
@@ -20,8 +20,8 @@ export default function useModalManager(params: IParamsConfigModal) {
   } = params
   const [isOpen, setIsOpen] = useState<boolean>(false)
 
-  function handleModalClose() {
-    if (preventClose) return
+  function handleModalClose(fromCloseButton?: boolean) {
+    if (preventClose && !fromCloseButton) return
     setIsOpen(false)
     onClose()
   }

--- a/src/stories/Anchor.stories.tsx
+++ b/src/stories/Anchor.stories.tsx
@@ -13,14 +13,14 @@ const Template: ComponentStory<typeof AnchorComponent> = (args) => (
 
 export const Anchor = Template.bind({})
 Anchor.args = {
-  to: '/anchor',
+  to: '/?path=/story/navigation-anchor--anchor',
   children: 'Click Anchor',
   className: 'text-primary'
 }
 
 export const LinkAnchor = Template.bind({})
 LinkAnchor.args = {
-  to: '/link',
+  to: '/?path=/story/navigation-anchor--link-anchor',
   children: 'Click Link',
   className: 'text-primary'
 }


### PR DESCRIPTION
✅ Closes: 77 - 80

## Summary
- Added validation to close the modal 
- Change the default URL of the Anchor component
- Update DD360 Logo URL
- Update of the call to the handleModalClose function

## Task

Issues 77 and 80


## Affected sections

- src/stories/Anchor.stories.tsx
- src/components/Modal/Modal.tsx
- src/hooks/useModalManager.ts
- .storybook/themes.js
- src/components/AsideModal/AsideModal.tsx

## How did you test this change?

- Mannualy with storybook :art: 
- All tests was passed ✅ 
