### PR TITLE
Fix: html change in tag component

### DIFF
--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -80,7 +80,7 @@ const Tag = ({
   const classSizeIcon = sizeIcon[fontSize]
 
   return (
-    <div role="container-tag" className={classNames} {...props}>
+    <span role="container-tag" className={classNames} {...props}>
       {Icon && (
         <Icon
           className={composeClasses(classSizeIcon, classNameIcon)}
@@ -89,7 +89,7 @@ const Tag = ({
         />
       )}
       {text}
-    </div>
+    </span>
   )
 }
 


### PR DESCRIPTION
The div tag was changed to span, in the Tag component

## Summary
Fix Initial Render Behavior (Hydration):
Since tags are used in paragraphs many times, a "p" tag cannot contain a "div"

Note: Some JavaScript frameworks and libraries, such as Next.js, can generate hydration errors if the HTML markup generated on the server does not exactly match the markup generated on the client. This might be relevant if you are using server-side rendering (SSR).


## Task
not

## Affected sections
- src/components/Tag/Tag.tsx

## How did you test this change?
Mannualy with storybook 🎨
All tests was passed ✅