### PR TITLE
Fix(Phase): Different statuses were added in the quarters variant

### DIFF
--- a/src/components/Phase/Phase.tsx
+++ b/src/components/Phase/Phase.tsx
@@ -3,11 +3,8 @@
  */
 
 import { ElementType } from 'react'
-import {
-  CheckCircleIcon,
-  SearchCircleIcon,
-  ExclamationIcon
-} from '@heroicons/react/solid'
+import { CheckCircleIcon, ExclamationIcon } from '@heroicons/react/solid'
+import { EyeIcon } from '@heroicons/react/outline'
 import { composeClasses } from 'lib/classes'
 import Divider from '../Divider'
 import Flex from '../Layout/Flex'
@@ -102,7 +99,11 @@ const phaseStyles: IClassStyles = {
 
 const ICON_STATUS = {
   completed: <CheckCircleIcon className="w-4 h-4 text-green-500" />,
-  onValidation: <SearchCircleIcon className="w-4 h-4 text-blue-500" />,
+  onValidation: (
+    <div className="bg-blue-500 p-0.5 rounded-full">
+      <EyeIcon className="w-3 h-3 text-white" />
+    </div>
+  ),
   missingInformation: <ExclamationIcon className="w-4 h-4 text-yellow-500" />
 }
 

--- a/src/components/Phase/Phase.tsx
+++ b/src/components/Phase/Phase.tsx
@@ -17,7 +17,7 @@ import Text from '../Typography'
 type Status = 'default' | 'active' | 'success' | 'selected' | 'completed'
 type Variants = 'phases' | 'status' | 'quarters'
 type TagVariants = 'primary' | 'secondary' | 'success' | 'warning'
-type IconStatus = 'completed' | 'onValidation' | 'missingInformation'
+type IconStatus = keyof typeof ICON_STATUS
 
 export interface IListItem {
   label: string
@@ -100,17 +100,10 @@ const phaseStyles: IClassStyles = {
   }
 }
 
-const iconStatus = (type: IconStatus) => {
-  switch (type) {
-    case 'completed':
-      return <CheckCircleIcon className="w-4 h-4 text-green-500" />
-    case 'onValidation':
-      return <SearchCircleIcon className="w-4 h-4 text-blue-500" />
-    case 'missingInformation':
-      return <ExclamationIcon className="w-4 h-4 text-yellow-500" />
-    default:
-      return <ExclamationIcon className="w-4 h-4 text-yellow-500" />
-  }
+const ICON_STATUS = {
+  completed: <CheckCircleIcon className="w-4 h-4 text-green-500" />,
+  onValidation: <SearchCircleIcon className="w-4 h-4 text-blue-500" />,
+  missingInformation: <ExclamationIcon className="w-4 h-4 text-yellow-500" />
 }
 
 const Phase = ({
@@ -199,7 +192,7 @@ const Phase = ({
                   <Text variant="p" size="sm" fontBold="medium">
                     {item.label}
                   </Text>
-                  {iconStatus(item.status)}
+                  {ICON_STATUS[item.status]}
                 </Flex>
               ))}
             </Flex>

--- a/src/components/Phase/Phase.tsx
+++ b/src/components/Phase/Phase.tsx
@@ -17,7 +17,7 @@ import Text from '../Typography'
 type Status = 'default' | 'active' | 'success' | 'selected' | 'completed'
 type Variants = 'phases' | 'status' | 'quarters'
 type TagVariants = 'primary' | 'secondary' | 'success' | 'warning'
-type IconStatus = keyof typeof ICON_STATUS
+export type IconStatus = keyof typeof ICON_STATUS
 
 export interface IListItem {
   label: string

--- a/src/components/Phase/Phase.tsx
+++ b/src/components/Phase/Phase.tsx
@@ -3,7 +3,11 @@
  */
 
 import { ElementType } from 'react'
-import { CheckCircleIcon, ExclamationCircleIcon } from '@heroicons/react/solid'
+import {
+  CheckCircleIcon,
+  SearchCircleIcon,
+  ExclamationIcon
+} from '@heroicons/react/solid'
 import { composeClasses } from 'lib/classes'
 import Divider from '../Divider'
 import Flex from '../Layout/Flex'
@@ -13,10 +17,11 @@ import Text from '../Typography'
 type Status = 'default' | 'active' | 'success' | 'selected' | 'completed'
 type Variants = 'phases' | 'status' | 'quarters'
 type TagVariants = 'primary' | 'secondary' | 'success' | 'warning'
+type IconStatus = 'completed' | 'onValidation' | 'missingInformation'
 
 export interface IListItem {
   label: string
-  completed: boolean
+  status: IconStatus
 }
 
 export interface IPhaseProps extends React.HTMLProps<HTMLDivElement> {
@@ -92,6 +97,19 @@ const phaseStyles: IClassStyles = {
       container: 'p-3 bg-gray-50 ring-2 ring-blue-400 text-gray-700 ',
       icon: 'text-gray-500'
     }
+  }
+}
+
+const iconStatus = (type: IconStatus) => {
+  switch (type) {
+    case 'completed':
+      return <CheckCircleIcon className="w-4 h-4 text-green-500" />
+    case 'onValidation':
+      return <SearchCircleIcon className="w-4 h-4 text-blue-500" />
+    case 'missingInformation':
+      return <ExclamationIcon className="w-4 h-4 text-yellow-500" />
+    default:
+      return <ExclamationIcon className="w-4 h-4 text-yellow-500" />
   }
 }
 
@@ -181,11 +199,7 @@ const Phase = ({
                   <Text variant="p" size="sm" fontBold="medium">
                     {item.label}
                   </Text>
-                  {item.completed ? (
-                    <CheckCircleIcon className="w-4 h-4 text-green-500" />
-                  ) : (
-                    <ExclamationCircleIcon className="w-4 h-4 text-yellow-600" />
-                  )}
+                  {iconStatus(item.status)}
                 </Flex>
               ))}
             </Flex>

--- a/src/stories/Phase.stories.tsx
+++ b/src/stories/Phase.stories.tsx
@@ -9,11 +9,11 @@ export default {
 } as ComponentMeta<typeof PhaseComponents>
 
 const data = [
-  { label: 'Anuales', completed: true },
-  { label: '4° Trimestre', completed: true },
-  { label: '3° Trimestre', completed: false },
-  { label: '2° Trimestre', completed: true },
-  { label: '1° Trimestre', completed: false }
+  { label: 'Anuales', status: 'completed' },
+  { label: '4° Trimestre', status: 'missingInformation' },
+  { label: '3° Trimestre', status: 'onValidation' },
+  { label: '2° Trimestre', status: 'completed' },
+  { label: '1° Trimestre', status: 'onValidation' }
 ]
 
 const Template: ComponentStory<typeof PhaseComponents> = (args) => (


### PR DESCRIPTION
## Summary

Different statuses were added in the quarters variant

## Task

not

## Affected sections

- src/components/Phase/Phase.tsx
- src/stories/Phase.stories.tsx

## How did you test this change?

* Mannualy with storybook 🎨
* Added test to phase component 🤖
* All tests was passed ✅ 