### PR TITLE
fix(Dropdown): close dropdown when click outside

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -2,8 +2,16 @@
  * Copyright (c) DD360 and its affiliates.
  */
 
-import { PropsWithoutRef, ReactElement, RefAttributes, useState } from 'react'
+import {
+  PropsWithoutRef,
+  ReactElement,
+  RefAttributes,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 import { composeClasses } from 'lib/classes'
+
 import DropdownMenu from './DropdownMenu'
 import DropdownTrigger from './DropdownTrigger'
 import { DropdownProvider } from './DropdownContext'
@@ -17,12 +25,30 @@ interface DropdownProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const Dropdown = ({ children, disableAnimation, ...props }: DropdownProps) => {
+  const ref = useRef<HTMLDivElement>(null)
   const [toggle, setToggle] = useState(false)
   const [trigger, menu] = children
 
+  useEffect(() => {
+    const handleClickOutside = (ev: any) => {
+      if (ref.current && !ref.current.contains(ev.target)) {
+        setToggle(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [])
+
   return (
     <DropdownProvider value={{ disableAnimation, toggle, setToggle }}>
-      <div {...props} className={composeClasses('relative', props.className)}>
+      <div
+        ref={ref}
+        {...props}
+        className={composeClasses('relative', props.className)}
+      >
         {trigger}
         {menu}
       </div>

--- a/src/stories/Dropdown.stories.tsx
+++ b/src/stories/Dropdown.stories.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+import DropdownComponent from '../components/Dropdown'
+import { Button } from '../components/Buttons'
+import Text from '../components/Typography/Text'
+
+export default {
+  title: 'components/Dropdown',
+  component: DropdownComponent
+} as ComponentMeta<typeof DropdownComponent>
+
+const Template: ComponentStory<typeof DropdownComponent> = ({
+  disableAnimation
+}) => (
+  <div className="flex justify-center">
+    <DropdownComponent disableAnimation={disableAnimation}>
+      <DropdownComponent.Trigger>
+        <Button className="h-10 pt-2 pb-3" paddingX="3">
+          <Text size="xs" bold className="text-white">
+            Trigger
+          </Text>
+        </Button>
+      </DropdownComponent.Trigger>
+      <DropdownComponent.Menu>
+        <Text className="px-5" size="base" bold>
+          Content
+        </Text>
+      </DropdownComponent.Menu>
+    </DropdownComponent>
+  </div>
+)
+
+export const Dropdown = Template.bind({})
+Dropdown.args = {
+  disableAnimation: false
+}


### PR DESCRIPTION
## Summary

Close dropdown when click outside of component

## Task

- Not


## Affected sections

- src\components\Dropdown\Dropdown.tsx
- src\stories\Dropdown.stories.tsx

## How did you test this change?

- Mannualy with storybook 🎨

