### PR TITLE
Fix(Pagination): display total items correctly

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -105,7 +105,7 @@ const Pagination = ({
         <select
           role="select-slice-size"
           name="custom-pagination"
-          value={selectSliceSize}
+          value={totalItems <= Number(sliceSize) ? totalItems : selectSliceSize}
           className="w-12 pl-2 mr-2 outline-none text-primary bg-transparent"
           onChange={(e) => handleChange(e)}
         >


### PR DESCRIPTION
## Summary

Display the total items text correctly when the total items are less than the slice size

## Task

- https://dd360.atlassian.net/browse/PD-502

## Affected sections

- src/components/Pagination/Pagination.tsx

## How did you test this change?

- Manually
