### PR TITLE
Fix(CurrencyInput): do not allow negative numbers when min value is zero

### DIFF
--- a/src/components/Form/Input/CurrencyInput.tsx
+++ b/src/components/Form/Input/CurrencyInput.tsx
@@ -208,7 +208,7 @@ const CurrencyInput = forwardRef<HTMLDivElement, InputCurrencyProps>(
             defaultValue={(defaultValue as string) || undefined}
             value={formattedValue()}
             allowDecimals={true}
-            allowNegativeValue={true}
+            allowNegativeValue={min === undefined || Number(min) < 0}
             step={undefined}
             onFocus={handleFocus}
             onBlur={handleBlur}
@@ -226,6 +226,8 @@ const CurrencyInput = forwardRef<HTMLDivElement, InputCurrencyProps>(
             }}
             onChange={undefined}
             onValueChange={handleOnChange}
+            max={max}
+            min={min}
           />
         )}
       </WrapperInput>


### PR DESCRIPTION
## Summary

Disable allow negative number when min prop is zero or more

## Task

none

## Affected sections

- src/components/Form/Input/CurrencyInput.tsx

## How did you test this change?

- Manually