### PR TITLE
Fix(Input): Disabled focus input type isCalendar

### DIFF
--- a/src/components/Form/Input/WrapperInput.tsx
+++ b/src/components/Form/Input/WrapperInput.tsx
@@ -46,7 +46,8 @@ const WrapperInput = forwardRef<HTMLDivElement, WrapperInputProps>(
       rounded,
       startAdornment,
       style,
-      variant
+      variant,
+      isCalendar
     } = props
 
     const { input, text, bgIcon } = inputVariants[variant]
@@ -66,6 +67,7 @@ const WrapperInput = forwardRef<HTMLDivElement, WrapperInputProps>(
         rounded && `rounded-${rounded}`,
         !['error', 'success', 'warning'].includes(variant) &&
           isFocused &&
+          !isCalendar &&
           'border-blue-500',
         isDisabled && !isCell && 'bg-gray-100 text-gray-400 cursor-not-allowed',
         !isDisabled && !isCell && 'hover:bg-white',


### PR DESCRIPTION
## Summary

Disabled focus input type isCalendar

## Task

- not

## Affected sections

- src/components/Form/Input/WrapperInput.tsx

## How did you test this change?

- Manually tested with Storybook 🎨
- All tests passed ✅
