### PR TITLE
Fix(Sidebar): Validation was changed when displaying tooltip

### DIFF
--- a/src/components/SideBar/SideBarItem.tsx
+++ b/src/components/SideBar/SideBarItem.tsx
@@ -115,8 +115,11 @@ const ListSubItems = ({
                       )}
                     </div>
                   )}
-                  {subItem?.title?.length > 19 ? (
-                    <Tooltip content={<Text>{subItem.title}</Text>}>
+                  {subItem?.title?.length > 23 ? (
+                    <Tooltip
+                      position="right"
+                      content={<Text>{subItem.title}</Text>}
+                    >
                       <Text
                         size="sm"
                         className={composeClasses(


### PR DESCRIPTION
## Summary

Validation was changed when displaying tooltip

## Task

- not

## Affected sections

- src/components/SideBar/SideBarItem.tsx

## How did you test this change?

- Manually tested with Storybook 🎨
- All tests passed ✅