### PR TITLE
Fix(Sidebar): Extended the character limit in tooltip validation

### DIFF
--- a/src/components/SideBar/SideBarItem.tsx
+++ b/src/components/SideBar/SideBarItem.tsx
@@ -115,7 +115,7 @@ const ListSubItems = ({
                       )}
                     </div>
                   )}
-                  {subItem?.title?.length > 23 ? (
+                  {subItem?.title?.length > 25 ? (
                     <Tooltip
                       position="right"
                       content={<Text>{subItem.title}</Text>}


### PR DESCRIPTION
## Summary

Extended the character limit in tooltip validation

## Task

- not

## Affected sections

- src/components/SideBar/SideBarItem.tsx

## How did you test this change?

- Manually tested with Storybook 🎨
- All tests passed ✅