### PR TITLE
Fix(Table): prevent table lines from disappearing when zooming in the browser

### DIFF
--- a/src/components/FileViewer/FileViewer.tsx
+++ b/src/components/FileViewer/FileViewer.tsx
@@ -206,16 +206,14 @@ const FileContent = ({
               />
             </div>
           ) : (
-            <>
-              <iframe
-                onLoad={() => {
-                  setIsLoaded(true)
-                }}
-                role="viewer-file"
-                className="w-full h-full"
-                src={`https://docs.google.com/gview?url=${encodedUrl}&embedded=true`}
-              />
-            </>
+            <iframe
+              onLoad={() => {
+                setIsLoaded(true)
+              }}
+              role="viewer-file"
+              className="w-full h-full"
+              src={`https://docs.google.com/gview?url=${encodedUrl}&embedded=true`}
+            />
           )}
         </div>
       ) : (

--- a/src/components/Table/table.css
+++ b/src/components/Table/table.css
@@ -37,7 +37,7 @@
   position: absolute;
   bottom: 0px;
   right: 0px;
-  width: 1px;
+  width: 0.1em;
   height: 100%;
   background-color: #8f969a;
   transform: translateZ(0);
@@ -54,6 +54,8 @@
   margin-bottom: 4px;
   margin-top: 4px;
   background-color: #d1d5db;
+  transform: translateZ(0);
+  -webkit-transform: translateZ(0);
 }
 
 .table-container-cmpnt.horizontal-borders thead tr th::before,
@@ -62,7 +64,7 @@
   position: absolute;
   bottom: 0px;
   right: 0px;
-  height: 1px;
+  height: 0.1em;
   width: 100%;
   background-color: #d1d5db;
   transform: translateZ(0);


### PR DESCRIPTION
## Summary

- Prevent table lines from disappearing when zooming in the browser

## Task

- https://dd360.atlassian.net/browse/PD-1032

## Affected sections

- src/components/FileViewer/FileViewer.tsx
- src/components/Table/table.css

## How did you test this change?

- Manually
