### PR TITLE
fix(Pagination): changed to a width auto

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -21,6 +21,14 @@ type Pages =
   | '55'
   | '60'
   | '65'
+  | '70'
+  | '75'
+  | '80'
+  | '85'
+  | '90'
+  | '95'
+  | '100'
+  | '105'
 
 export interface PaginationProps {
   totalPages: number
@@ -106,7 +114,7 @@ const Pagination = ({
           role="select-slice-size"
           name="custom-pagination"
           value={totalItems <= Number(sliceSize) ? totalItems : selectSliceSize}
-          className="w-12 pl-2 mr-2 outline-none text-primary bg-transparent"
+          className="w-auto pl-2 mr-2 outline-none text-primary bg-transparent"
           onChange={(e) => handleChange(e)}
         >
           {options.map((opt) => {

--- a/src/stories/Pagination.stories.tsx
+++ b/src/stories/Pagination.stories.tsx
@@ -15,12 +15,12 @@ const mockFn = (text: string) => alert(text)
 
 export const Pagination = Template.bind({})
 Pagination.args = {
-  totalRows: 30,
+  totalRows: 120,
   totalPages: 10,
   currentPage: 1,
   sliceSize: '5' as any,
   firstText: 'Show',
-  secondText: 'of 30 projects',
+  secondText: 'of 120 projects',
   goToPreviousPage: () => mockFn('Go to previous page'),
   goToNextPage: () => mockFn('Go to next page'),
   goToPage: () => mockFn('Go to x page'),


### PR DESCRIPTION
## Summary

The width size was changed because when selecting the pagination with a 3-digit value it was cut off.

## Task

https://dd360.atlassian.net/browse/PD-1227


## Affected sections

- src/components/Pagination/Pagination.tsx
- src/stories/Pagination.stories.tsx

## How did you test this change?

- Manually tested with Storybook 🎨
- All tests passed ✅
