### PR TITLE
Fix(PageTemplate): Change width filter bar search

### DIFF
--- a/src/components/PageTemplate/PageTemplate.tsx
+++ b/src/components/PageTemplate/PageTemplate.tsx
@@ -156,7 +156,7 @@ const PageTemplate: FC<PageTemplateProps> = ({
             <FilterBar className="flex-wrap">
               {search && (
                 <FilterBar.Section
-                  className={smallSearch ? 'w-12 xl:w-60' : 'w-full sm:w-60'}
+                  className={smallSearch ? 'w-12 xl:w-80' : 'w-full sm:w-80'}
                 >
                   <FilterSearch {...search} smallSearch={smallSearch} />
                 </FilterBar.Section>


### PR DESCRIPTION
## Summary

Change width filter bar search

## Task

- not

## Affected sections

- src/components/PageTemplate/PageTemplate.tsx

## How did you test this change?

- Manually tested
- All tests passed ✅
