### PR TITLE
Fix(Select): added prop className to the dropdown of the select component

### DIFF
--- a/src/components/Form/Select.tsx
+++ b/src/components/Form/Select.tsx
@@ -55,6 +55,7 @@ export interface SelectProps extends InputHTMLAttributes<HTMLInputElement> {
   optionsList: ISelectOptions
   itemWidth?: 'trimWithEllipsis' | 'fullWidth' | 'textWrap'
   isRequired?: boolean
+  classNameDropdown?: string
 }
 
 const IconStatus = ({ variant }: { variant: SelectVariantType }) => {
@@ -144,6 +145,7 @@ function Select({
   placeholder,
   itemWidth = 'trimWithEllipsis',
   isRequired,
+  classNameDropdown,
   ...otherProps
 }: SelectProps) {
   const { disabled } = otherProps
@@ -336,6 +338,7 @@ function Select({
       <div
         role="dropdown"
         className={composeClasses(
+          classNameDropdown,
           'absolute left-0 z-10 w-full py-1 mt-1 bg-white overflow-y-auto',
           isSecondary ? 'top-7' : `top-${large ? '13' : '12'}`,
           `rounded-${rounded} shadow-${boxShadow}`,


### PR DESCRIPTION
## Summary

Added prop className to the dropdown of the select component

## Task

- not

## Affected sections

- src/components/Form/Select.tsx

## How did you test this change?

- Manually tested with Storybook 🎨
- All tests passed ✅
