### PR TITLE
Fix: display pencil icon on index cell

### DIFF
--- a/src/components/TableV2/base/TableCell.tsx
+++ b/src/components/TableV2/base/TableCell.tsx
@@ -1,8 +1,8 @@
 import { HTMLAttributes } from 'react'
 import { composeClasses } from 'lib/classes'
-import { Flex } from 'components/Layout'
 import Input, { GenericInputProps } from '../../Form/Input/Input'
 import CellText from './TableCellText'
+import IndexCell from './TableIndexCell'
 
 type unit = `${number}${'px' | 'rem'}`
 
@@ -170,19 +170,7 @@ const Cell = ({
         ...props.style
       }}
     >
-      {indexCell && (
-        <Flex
-          alignItems="center"
-          justifyContent="center"
-          className={composeClasses(
-            onEdit && 'hover:bg-blue-300 cursor-pointer',
-            'absolute top-0 left-0 w-6 h-full bg-gray-200 transition-all duration-300 ease-linear'
-          )}
-          onClick={onEdit}
-        >
-          {indexCell}
-        </Flex>
-      )}
+      {indexCell && <IndexCell onEdit={onEdit} indexCell={indexCell} />}
       {inputProps ? (
         <Input
           paddingX="0"

--- a/src/components/TableV2/base/TableIndexCell.tsx
+++ b/src/components/TableV2/base/TableIndexCell.tsx
@@ -1,0 +1,59 @@
+import { ReactNode } from 'react'
+import { PencilIcon } from '@heroicons/react/outline'
+import { composeClasses } from 'lib/classes'
+import { Flex } from 'components/Layout'
+
+export interface IndexCellProps {
+  /**
+   * Index of the cell
+   */
+  indexCell: number
+  /**
+   * Function to call when cell is edited
+   */
+  onEdit?: () => void
+}
+
+const IndexWrapper = ({
+  className,
+  children,
+  onClick
+}: {
+  children: ReactNode
+  className?: string
+  onClick?: () => void
+}) => {
+  return (
+    <Flex
+      alignItems="center"
+      justifyContent="center"
+      className={composeClasses('absolute top-0 left-0 w-6 h-full', className)}
+      onClick={(e) => {
+        e.stopPropagation()
+        onClick && onClick()
+      }}
+    >
+      {children}
+    </Flex>
+  )
+}
+
+const IndexCell = ({ onEdit, indexCell }: IndexCellProps) => {
+  return (
+    <>
+      <IndexWrapper className="bg-gray-200 cursor-default">
+        {indexCell}
+      </IndexWrapper>
+      {onEdit && (
+        <IndexWrapper
+          className="opacity-0 group-hover:opacity-100 bg-blue-700 text-white transition-all duration-200 ease-linear cursor-pointer"
+          onClick={onEdit}
+        >
+          <PencilIcon className="w-3 h-3" />
+        </IndexWrapper>
+      )}
+    </>
+  )
+}
+
+export default IndexCell

--- a/src/components/TableV2/base/TableRow.tsx
+++ b/src/components/TableV2/base/TableRow.tsx
@@ -28,7 +28,7 @@ const Row = ({ variant = 'default', ...props }: RowProps) => {
       {...props}
       className={composeClasses(
         props.className,
-        'hover:bg-gray-50',
+        'hover:bg-gray-50 group',
         fontWeight.medium,
         rowVariant[variant]
       )}


### PR DESCRIPTION
## Summary

- Display a pencil icon when Cell component has onEdit prop on hover

## Task

- https://dd360.atlassian.net/browse/PD-1158

## Affected sections

- src/components/TableV2/base/TableCell.tsx
- src/components/TableV2/base/TableIndexCell.tsx
- src/components/TableV2/base/TableRow.tsx

## How did you test this change?

- Manually
