### PR TITLE
Fix: table variant row color

### DIFF
--- a/src/components/TableV2/base/TableCell.tsx
+++ b/src/components/TableV2/base/TableCell.tsx
@@ -82,7 +82,7 @@ export interface CellProps
    * result: commonly used to display a row of subtotals
    * default: apply the base styles
    */
-  variant?: 'result' | 'default' | 'summary'
+  variant?: 'result' | 'default' | 'summary' | 'highlight'
   /**
    * Show a shadow when cell is sticky
    */
@@ -134,6 +134,8 @@ const Cell = ({
           return '#374151'
         case 'result':
           return '#F9FAFB'
+        case 'highlight':
+          return '#F3F4F6'
         default:
           return '#FFFFFF'
       }

--- a/src/components/TableV2/base/TableRow.tsx
+++ b/src/components/TableV2/base/TableRow.tsx
@@ -8,16 +8,17 @@ export interface RowProps extends React.HTMLAttributes<HTMLTableRowElement> {
   children?: React.ReactNode
   /**
    *  Row variants
-   * header: commonly used to display a row of titles
+   * highlight: commonly used to display a highlighted row
    * result: commonly used to display a row of totals
+   * summary: commonly used to display a summary row
    * default: apply the base styles
    */
-  variant?: 'header' | 'result' | 'default' | 'summary'
+  variant?: 'highlight' | 'result' | 'default' | 'summary'
 }
 
 const rowVariant: { [key: string]: string } = {
   default: `${fontSize.xxs} h-7 text-gray-700 bg-transparent`,
-  header: `${fontSize.sm} ${fontWeight.bold} text-gray-900 bg-gray-100`,
+  highlight: `${fontSize.xxs} text-gray-900 bg-gray-100 hover:bg-gray-100`,
   result: `${fontSize.xxs} text-gray-900 bg-gray-50`,
   summary: `${fontSize.xxs} bg-gray-700 hover:bg-gray-700 text-white`
 }


### PR DESCRIPTION
## Summary

- Rename variant 'header' to 'highlight' on table row and cell row
- Change text size and hover color

## Task

none

## Affected sections

- src/components/TableV2/base/TableCell.tsx
- src/components/TableV2/base/TableRow.tsx

## How did you test this change?

- Manually
