### PR TITLE
Fix: negative number on currency cell

### DIFF
--- a/src/components/TableV2/base/TableCellText.tsx
+++ b/src/components/TableV2/base/TableCellText.tsx
@@ -49,8 +49,9 @@ const CellText = ({
 
   const values = useMemo(() => {
     if (type === 'currency') {
+      const num = Number(children)
       return {
-        value: `$${formatCustomDecimal(Number(children))}`
+        value: `${num < 0 ? '-$' : '$'}${formatCustomDecimal(Math.abs(num))}`
       }
     } else if (type === 'percentage') {
       return {


### PR DESCRIPTION
## Summary

- Display the negative sign in the right position in the currency cell

## Task

none

## Affected sections

- src/components/TableV2/base/TableCellText.tsx

## How did you test this change?

- Manually
