### PR TITLE
Fix(Tooltip): Add props noOpacity tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -37,10 +37,12 @@ export interface TooltipProps {
    * primary by default
    */
   variant?: TooltipVariant
-}
-
-const colorVariants: { [key: string]: string } = {
-  primary: `text-center ${fontSize.xs} bg-gray-900 opacity-70 p-2 text-white rounded-md`
+  /**
+   * If true, the tooltip will use a solid color without any opacity.
+   * This is useful when you need a fully opaque background or text color.
+   * By default, this is set to false, allowing for transparency if defined in the variant styles.
+   */
+  noOpacity?: boolean
 }
 
 const Tooltip: FC<TooltipProps> = ({
@@ -49,7 +51,8 @@ const Tooltip: FC<TooltipProps> = ({
   endAdornment,
   position,
   startAdornment,
-  variant = 'primary'
+  variant = 'primary',
+  noOpacity = false
 }) => {
   const { isVisible, handleMouseEnter, handleMouseLeave, refs } = useTooltip({
     placement: position
@@ -62,6 +65,14 @@ const Tooltip: FC<TooltipProps> = ({
     onMouseEnter: handleMouseEnter,
     onMouseLeave: handleMouseLeave
   })
+
+  const colorVariants: { [key: string]: string } = {
+    primary: composeClasses(
+      !noOpacity && 'opacity-70',
+      fontSize.xs,
+      'p-2 text-white rounded-md text-center bg-gray-900'
+    )
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary

Add props noOpacity tooltip

## Task

- not

## Affected sections

- src/components/Tooltip/Tooltip.tsx

## How did you test this change?

- Manually tested with Storybook 🎨
- All tests passed ✅