### PR TITLE
Fix(TopPage): added the possibility to send all tooltip props in the top page …

### DIFF
--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -5,7 +5,7 @@
 import { useMemo, useCallback, forwardRef } from 'react'
 import { composeClasses } from 'lib/classes'
 import { ClockIcon } from '@heroicons/react/outline'
-import Tooltip from 'components/Tooltip'
+import Tooltip, { TooltipProps } from 'components/Tooltip'
 
 interface PrivateProps {
   onChange?: (event: React.MouseEvent<HTMLButtonElement>) => void
@@ -28,7 +28,7 @@ interface Props
   isVertical?: boolean
   tabWidth?: number
   tabMinWidth?: number
-  tooltipLabel?: string
+  toolTipsProps?: TooltipProps
 }
 
 const variantStyle = {
@@ -51,7 +51,7 @@ const Tab = forwardRef<HTMLButtonElement, Props>(
       isVertical,
       tabWidth,
       tabMinWidth,
-      tooltipLabel,
+      toolTipsProps,
       ...otherProps
     },
     ref
@@ -133,8 +133,15 @@ const Tab = forwardRef<HTMLButtonElement, Props>(
 
     return (
       <>
-        {tooltipLabel ? (
-          <Tooltip position="right" content={tooltipLabel}>
+        {toolTipsProps ? (
+          <Tooltip
+            variant={toolTipsProps.variant ?? 'primary'}
+            endAdornment={toolTipsProps.endAdornment}
+            startAdornment={toolTipsProps.startAdornment}
+            position={toolTipsProps.position ?? 'right'}
+            content={toolTipsProps.content ?? ''}
+            noOpacity={toolTipsProps.noOpacity}
+          >
             {renderTab()}
           </Tooltip>
         ) : (

--- a/src/components/TopPage/TopPage.tsx
+++ b/src/components/TopPage/TopPage.tsx
@@ -14,6 +14,7 @@ import { Tab, TabGroup } from 'components/Tabs'
 import Divider from 'components/Divider'
 import Text from '../Typography'
 import { monthLabelsShort } from '../../utils/utils'
+import { TooltipProps } from 'components/Tooltip'
 
 export interface ActionButtonProps {
   onClick: () => void
@@ -32,7 +33,7 @@ export interface TabTopPageProps {
     label: string
     disabled?: boolean
     hidden?: boolean
-    tooltipLabel?: string
+    toolTipProps?: TooltipProps
   }[]
 }
 
@@ -210,7 +211,7 @@ const TopPage = ({
                 label={tab.label}
                 disabled={tab.disabled}
                 hidden={tab.hidden}
-                tooltipLabel={tab.tooltipLabel}
+                toolTipsProps={tab.toolTipProps}
               />
             ))}
           </TabGroup>


### PR DESCRIPTION
## Summary

Added the possibility to send all tooltip props in the top page tabs

## Task

- not

## Affected sections

- src/components/Tabs/Tab.tsx
- src/components/TopPage/TopPage.tsx

## How did you test this change?

- Manually tested with Storybook 🎨
- All tests passed ✅
