### PR TITLE
Fix(Date Picker): Order of the years in date picker was inverted

### DIFF
--- a/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/components/DatePicker/DatePicker.test.tsx
@@ -231,7 +231,7 @@ describe('<DatePicker /> ', () => {
         fireEvent.click(getByRole('pevRangeYear'))
         today.setFullYear(today.getFullYear() - 11)
         expect(getByRole('range-years').firstChild?.textContent).toEqual(
-          `${today.getFullYear()} - ${today.getFullYear() - 10}`
+          `${today.getFullYear() - 10} - ${today.getFullYear()}`
         )
       })
 
@@ -243,7 +243,7 @@ describe('<DatePicker /> ', () => {
         fireEvent.click(getByRole('nextRangeYear'))
         today.setFullYear(today.getFullYear() + 11)
         expect(getByRole('range-years').firstChild?.textContent).toEqual(
-          `${today.getFullYear()} - ${today.getFullYear() - 10}`
+          `${today.getFullYear() - 10} - ${today.getFullYear()}`
         )
       })
     })

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -324,7 +324,7 @@ function Calendar({
             onClick={updateCurrentOption}
           >
             <Text bold size="sm">
-              {yearList[yearList.length - 1]} - {yearList[0]}
+              {yearList[0]} - {yearList[yearList.length - 1]}
             </Text>
           </button>
           <button


### PR DESCRIPTION
## Summary

Order of the years in date picker was inverted

## Task

- not

## Affected sections

- src/components/DatePicker/DatePicker.test.tsx
- src/components/DatePicker/DatePicker.tsx

## How did you test this change?

- Manually tested with Storybook 🎨
- All tests passed ✅
