### PR TITLE
Fix(PageTemplate): add z-index on footer and hide toppage boolean

### DIFF
--- a/src/components/PageTemplate/PageTemplate.tsx
+++ b/src/components/PageTemplate/PageTemplate.tsx
@@ -69,6 +69,8 @@ interface PageTemplateProps extends TopPageProps {
   role?: string
   /** Hides the filter bar when true */
   hiddenFilterBar?: boolean
+  /** Hides the top page when true */
+  hiddenTopPage?: boolean
 }
 
 const PageTemplate: FC<PageTemplateProps> = ({
@@ -83,6 +85,7 @@ const PageTemplate: FC<PageTemplateProps> = ({
   arrowSelector,
   role,
   hiddenFilterBar,
+  hiddenTopPage,
   ...otherProps
 }) => {
   const filterComponents = [
@@ -149,7 +152,7 @@ const PageTemplate: FC<PageTemplateProps> = ({
 
   return (
     <div role={role}>
-      <TopPage {...otherProps} />
+      {!hiddenTopPage && <TopPage {...otherProps} />}
       <div className="px-5">
         <div className="my-4">
           {hasFilterBar && (
@@ -223,7 +226,7 @@ const PageTemplate: FC<PageTemplateProps> = ({
         {children}
       </div>
       {footer && (
-        <div className="absolute bottom-0 left-5 right-5">
+        <div className="absolute bottom-0 left-5 right-5 z-30">
           <div className="mb-2">{footer}</div>
         </div>
       )}

--- a/src/components/TopPage/TopPage.tsx
+++ b/src/components/TopPage/TopPage.tsx
@@ -66,7 +66,7 @@ export interface TopPageProps {
   /** Last update information with date and translation */
   lastUpdate?: LastUpdateTopPageProps
   /** Page title with label and loading state */
-  title: TitleTopPageProps
+  title?: TitleTopPageProps
   /** Optional description displayed below the title */
   description?: string
   /** List of action buttons with labels, icons, and onClick handlers */
@@ -142,11 +142,11 @@ const TopPage = ({
         }}
       >
         <Flex className="flex-col">
-          {title.isLoading ? (
+          {title?.isLoading ? (
             <Skeleton className="w-48 h-9 rounded-full" />
           ) : (
             <Text role="title-label" bold size="2xl">
-              {title.label}
+              {title?.label}
             </Text>
           )}
           {description && (


### PR DESCRIPTION
## Summary

- Add hiddenTopPage prop to hide top page
- Add z-index on footer

## Task

- https://dd360.atlassian.net/browse/PD-1049

## Affected sections

- src/components/PageTemplate/PageTemplate.tsx

## How did you test this change?

- Manually
