### PR TITLE
Fix: Add min width button aside modal v2

### DIFF
--- a/src/components/AsideModalV2/AsideModalV2.tsx
+++ b/src/components/AsideModalV2/AsideModalV2.tsx
@@ -126,6 +126,7 @@ const AsideModalV2: FC<AsideModalProps> = ({
                   size={button.size || 'small'}
                   onClick={button.onClick}
                   className="px-6"
+                  style={{ minWidth: '130px' }}
                   disabled={button.disabled}
                   isLoading={button.isLoading}
                 >


### PR DESCRIPTION
## Summary

Add min width button aside modal v2

## Task

- not

## Affected sections

- src/components/AsideModalV2/AsideModalV2.tsx

## How did you test this change?

- Manually tested with Storybook 🎨
- All tests passed ✅